### PR TITLE
Add Streamlit demo to explore poietic freedom cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ make pipeline
 >
 > Swap them for domain-grade metrics in your study (formal MDL, community/modularity, domain-controlled surprisal, etc.). See `docs/METHODS.md`.
 
+### C) Streamlit demo
+
+Launch an interactive app to explore case files or enter your own examples:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+The app computes the proxy signals and `L*` for the selected inputs.
+
 ---
 
 ## Case File Schema (tl;dr)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -1,35 +1,15 @@
-import json, glob, os, pandas as pd
-from src.lstar import l_star, DEFAULT_WEIGHTS
-from src.mdl_delta import mdl_delta
-from src.network_rupture import load_edge_list_csv, rupture_score
+import glob
+import os
+import pandas as pd
+from src.pipeline import eval_case
 
-def load_text(path):
-    try:
-        with open(path, 'r', encoding='utf-8') as f:
-            return f.read()
-    except FileNotFoundError:
-        return ""
-
-def eval_case(case_path: str) -> dict:
-    case = json.load(open(case_path, 'r', encoding='utf-8'))
-    cid = case.get("id"); domain = case.get("domain"); title = case.get("title")
-    corp = case.get("corpora", {}); graph = case.get("graphs", {})
-    pre_text = load_text(corp.get("pre", "")); post_text = load_text(corp.get("post", ""))
-    mdl = mdl_delta(pre_text, post_text) if pre_text and post_text else None
-    if graph.get("pre") and graph.get("post"):
-        G0 = load_edge_list_csv(graph["pre"]); G1 = load_edge_list_csv(graph["post"])
-        rupt = rupture_score(G0, G1)
-    else:
-        rupt = None
-    scores = case.get("Lstar", {})
-    L = l_star(scores) if scores else None
-    return {"id": cid, "domain": domain, "title": title, "mdl_delta": mdl, "network_rupture": rupt, "L_star": L}
 
 def main():
     rows = [eval_case(p) for p in glob.glob("data/case_files/**/**/*.json", recursive=True)]
     os.makedirs("outputs", exist_ok=True)
     pd.DataFrame(rows).to_csv("outputs/report.csv", index=False)
     print("Wrote outputs/report.csv with", len(rows), "rows.")
+
 
 if __name__ == "__main__":
     main()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,0 +1,41 @@
+import json
+from typing import Dict, Any
+from .lstar import l_star
+from .mdl_delta import mdl_delta
+from .network_rupture import load_edge_list_csv, rupture_score
+
+
+def load_text(path: str) -> str:
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        return ""
+
+
+def eval_case(case_path: str) -> Dict[str, Any]:
+    case = json.load(open(case_path, 'r', encoding='utf-8'))
+    cid = case.get("id")
+    domain = case.get("domain")
+    title = case.get("title")
+    corp = case.get("corpora", {})
+    graph = case.get("graphs", {})
+    pre_text = load_text(corp.get("pre", ""))
+    post_text = load_text(corp.get("post", ""))
+    mdl = mdl_delta(pre_text, post_text) if pre_text and post_text else None
+    if graph.get("pre") and graph.get("post"):
+        G0 = load_edge_list_csv(graph["pre"])
+        G1 = load_edge_list_csv(graph["post"])
+        rupt = rupture_score(G0, G1)
+    else:
+        rupt = None
+    scores = case.get("Lstar", {})
+    L = l_star(scores) if scores else None
+    return {
+        "id": cid,
+        "domain": domain,
+        "title": title,
+        "mdl_delta": mdl,
+        "network_rupture": rupt,
+        "L_star": L,
+    }

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,43 @@
+import glob
+import io
+import csv
+import networkx as nx
+import streamlit as st
+from src.pipeline import eval_case
+from src.mdl_delta import mdl_delta
+from src.network_rupture import rupture_score
+from src.lstar import l_star, DEFAULT_WEIGHTS
+
+st.title("ANIMa-10 Poietic Freedom Demo")
+
+case_files = ["" ] + sorted(glob.glob("data/case_files/**/**/*.json", recursive=True))
+case_path = st.selectbox("Choose a case file", case_files)
+
+if case_path:
+    result = eval_case(case_path)
+    st.subheader("Case results")
+    st.json(result)
+
+st.header("Manual Example")
+pre_text = st.text_area("Pre text", height=150)
+post_text = st.text_area("Post text", height=150)
+if pre_text and post_text:
+    st.write("MDL Δ:", mdl_delta(pre_text, post_text))
+
+pre_edges = st.file_uploader("Pre graph (CSV edge list)", type="csv", key="pre")
+post_edges = st.file_uploader("Post graph (CSV edge list)", type="csv", key="post")
+if pre_edges and post_edges:
+    def load_graph(upload):
+        upload.seek(0)
+        G = nx.Graph()
+        for row in csv.reader(io.StringIO(upload.getvalue().decode("utf-8"))):
+            if row and not row[0].startswith('#'):
+                G.add_edge(row[0], row[1])
+        return G
+    G0 = load_graph(pre_edges)
+    G1 = load_graph(post_edges)
+    st.write("Network rupture:", rupture_score(G0, G1))
+
+st.subheader("L* score")
+scores = {k: st.selectbox(k, [0, 1], format_func=lambda x: "Yes" if x else "No") for k in DEFAULT_WEIGHTS}
+st.write("L* =", l_star(scores))


### PR DESCRIPTION
## Summary
- factor out pipeline case evaluation into `src/pipeline.py`
- add a Streamlit app for exploring case files and manual examples
- document how to launch the demo

## Testing
- `python -m pip install numpy pandas networkx streamlit pytest` *(fails: 403 Forbidden)*
- `python -m pytest` *(fails: No module named 'numpy')*
- `python scripts/run_pipeline.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68b4a358b24c8326a177dc32c2b7d3cd